### PR TITLE
fix(colormodeobserver): replace theme-ui hook with custom version

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -51,8 +51,8 @@ export const ColorModeTool: React.FC<ColorModeToolProps> = (
   const active = state.currentId !== DEFAULT_MODE_ID
 
   const updateMode = (id: string): void => {
-    setState({ currentId: id })
     props.channel.emit(CHANGE_MODE, id)
+    setState({ currentId: id })
   }
 
   return (

--- a/src/__tests__/ColorModeObserver.test.tsx
+++ b/src/__tests__/ColorModeObserver.test.tsx
@@ -1,16 +1,10 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, act } from '@testing-library/react'
 import { ColorModeObserver } from '../components/ColorModeObserver'
 import { ColorModeChannel } from '../models'
 import { CHANGE_MODE } from '../constants'
 
 const mockSetMode = jest.fn()
-jest.mock('theme-ui', () => ({
-  ...jest.requireActual('theme-ui'),
-  useColorMode: jest.fn(() => {
-    return ['default', mockSetMode]
-  }),
-}))
 
 interface Registry {
   [key: string]: (mode: string) => void
@@ -35,7 +29,7 @@ describe('ColorModeObserver', () => {
 
   test('renders initial styles properly', () => {
     const { container } = render(
-      <ColorModeObserver channel={mockChannel}>
+      <ColorModeObserver theme={{}} channel={mockChannel}>
         <h1>This is a test</h1>
       </ColorModeObserver>
     )
@@ -45,7 +39,7 @@ describe('ColorModeObserver', () => {
 
   test('a listener should be added upon mounting', () => {
     render(
-      <ColorModeObserver channel={mockChannel}>
+      <ColorModeObserver theme={{}} channel={mockChannel}>
         <h1>This is a test</h1>
       </ColorModeObserver>
     )
@@ -55,7 +49,7 @@ describe('ColorModeObserver', () => {
 
   test('a listener should be removed upon unmounting', () => {
     const { unmount } = render(
-      <ColorModeObserver channel={mockChannel}>
+      <ColorModeObserver theme={{}} channel={mockChannel}>
         <h1>This is a test</h1>
       </ColorModeObserver>
     )
@@ -65,29 +59,39 @@ describe('ColorModeObserver', () => {
     expect(mockChannel.removeListener).toBeCalledTimes(1)
   })
 
-  test('set mode should have been triggered upon emitting the CHANGE_MODE event', () => {
+  test('emit CHANGE_MODE should set the class of the body element', () => {
     render(
-      <ColorModeObserver channel={mockChannel}>
+      <ColorModeObserver theme={{}} channel={mockChannel}>
         <h1>This is a test</h1>
       </ColorModeObserver>
     )
 
-    // Roughly equiviant to the emit method
-    registry[CHANGE_MODE]('dark')
+    act(() => {
+      registry[CHANGE_MODE]('dark')
+    })
 
-    expect(mockSetMode).toBeCalledTimes(1)
+    expect(document.body.className).toEqual('theme-ui-dark')
   })
 
-  test('set mode should not be triggered upon emitting the CHANGE_MODE event for the already set mode', () => {
+  test('emit CHANGE_MODE should remove the class of the previous mode', () => {
     render(
-      <ColorModeObserver channel={mockChannel}>
+      <ColorModeObserver theme={{}} channel={mockChannel}>
         <h1>This is a test</h1>
       </ColorModeObserver>
     )
 
-    // roughly equivilant to the emit method
-    registry[CHANGE_MODE]('default')
+    act(() => {
+      registry[CHANGE_MODE]('dark')
+    })
 
-    expect(mockSetMode).toBeCalledTimes(0)
+    act(() => {
+      registry[CHANGE_MODE]('default')
+    })
+
+    act(() => {
+      registry[CHANGE_MODE]('default')
+    })
+
+    expect(document.body.className).toEqual('theme-ui-default')
   })
 })

--- a/src/components/ColorModeObserver.tsx
+++ b/src/components/ColorModeObserver.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { ColorModeChannel } from '../models'
-import { Styled, ColorMode, useColorMode } from 'theme-ui'
+import { Styled, ColorMode, Theme } from 'theme-ui'
 import { CHANGE_MODE } from '../constants'
+import { ThemeProvider } from 'emotion-theming'
 
 interface ColorModeObserverProps {
+  theme: Theme
   children: React.ReactNode
   channel: ColorModeChannel
 }
@@ -11,11 +13,14 @@ interface ColorModeObserverProps {
 export const ColorModeObserver: React.FC<ColorModeObserverProps> = (
   props: ColorModeObserverProps
 ) => {
-  const [mode, setMode] = useColorMode()
+  const [mode, setMode] = useState()
 
   useEffect(() => {
     const handleEvent = (newMode: string): void => {
       if (mode !== newMode) {
+        document.body.classList.remove('theme-ui-' + mode)
+        document.body.classList.add('theme-ui-' + newMode)
+
         setMode(newMode)
       }
     }
@@ -28,9 +33,9 @@ export const ColorModeObserver: React.FC<ColorModeObserverProps> = (
   }, [mode, props.channel, setMode])
 
   return (
-    <>
+    <ThemeProvider theme={props.theme}>
       <ColorMode />
       <Styled.root>{props.children}</Styled.root>
-    </>
+    </ThemeProvider>
   )
 }

--- a/src/withThemeProvider.tsx
+++ b/src/withThemeProvider.tsx
@@ -4,7 +4,7 @@ import addons, {
   MakeDecoratorResult,
   StoryWrapper,
 } from '@storybook/addons'
-import { ThemeProvider, Theme } from 'theme-ui'
+import { Theme } from 'theme-ui'
 import { ColorModeObserver } from './components/ColorModeObserver'
 
 export const makeWrapperWithTheme = (theme: Theme): StoryWrapper => (
@@ -14,9 +14,9 @@ export const makeWrapperWithTheme = (theme: Theme): StoryWrapper => (
   const channel = addons.getChannel()
 
   return (
-    <ThemeProvider theme={theme}>
-      <ColorModeObserver channel={channel}>{story(context)}</ColorModeObserver>
-    </ThemeProvider>
+    <ColorModeObserver theme={theme} channel={channel}>
+      {story(context)}
+    </ColorModeObserver>
   )
 }
 


### PR DESCRIPTION
Theme UI's useColorMode hook uses the localstorage which doesn't seem to interact very well with
iframes. Instead of relying on this mechanism we simplify the the hook by just changing the
classname on the body element.

fix #4